### PR TITLE
Remove unncessary -no-integrated-as flag.

### DIFF
--- a/Android.v8common.mk
+++ b/Android.v8common.mk
@@ -26,10 +26,6 @@ LOCAL_CFLAGS += \
 LOCAL_CFLAGS_arm += -DV8_TARGET_ARCH_ARM
 LOCAL_CFLAGS_arm64 += -DV8_TARGET_ARCH_ARM64
 
-# atomicops_internals_arm64_gcc.h:77:49: error:
-# expected compatible register, symbol or integer in range [0, 4095]
-LOCAL_CLANG_CFLAGS_arm64 += -no-integrated-as
-
 LOCAL_CFLAGS_mips += -DV8_TARGET_ARCH_MIPS \
 	-Umips \
 	-finline-limit=64 \


### PR DESCRIPTION
Bug: http://b/18789533
Test: Rebuilt aosp_angler with/without flag successfully.

This flag was added to work around a Clang assembler issue
(unimplemented support for this instruction). Now that this issue is
fixed and available in Android's Clang, we can remove the flag.

Change-Id: Ia71fa04b6728f012b4f199fb0027c69795542354